### PR TITLE
Adicionando dica sobre o uso de transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ O não cumprimento de um requisito, total ou parcialmente, impactará em sua ava
 
 ## Dicas
 
+- A propriedade `transform` só funciona em elementos do tipo `block` ou `inline-block`. Então, é sugerido adicionar a propriedade `display: inline-block` para que os elementos spans apresentem o conteúdo da forma correta.
+
 - [Que tal](https://flaviocopes.com/how-to-add-event-listener-multiple-elements-javascript/) usar um _loop_ para adicionar o mesmo evento em vários elementos? [Ou então](https://gomakethings.com/attaching-multiple-elements-to-a-single-event-listener-in-vanilla-js/) a técnica de _event bubbling_ combinada com `classList`?
 
 - Se precisar consultar os valores do _CSS_ de um elemento a partir do _JavaScript_, [dê uma olhada aqui](https://www.w3schools.com/jsref/jsref_getcomputedstyle.asp).


### PR DESCRIPTION
Depois de uma thread levantada por uma pessoa estudante foi observado que a propriedade transform só funciona em elementos do tipo `block`, ou seja a propriedade `display` deve ser igual a `block` ou `inline-block`. Para garantir que as palavras vão ficar uma ao lado da outra o apropriado é  usar a segunda opção.